### PR TITLE
fix for closed profiles/guides. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - Gordon surfaces can be created now without the need to duplicate curves in case of closed surfaces.
+   This should make it much easier to integrate into CAD tools.
+   __Note__: this is optional. The previous behavior still works.
+   Thanks: @Shkolik 🙏
+
 ### Added
 ### Fixed
-### Changed

--- a/src/internal/BSplineAlgorithms.cpp
+++ b/src/internal/BSplineAlgorithms.cpp
@@ -359,6 +359,7 @@ namespace occ_gordon_internal
 {
 
 const double BSplineAlgorithms::REL_TOL_CLOSED = 1e-8;
+const double BSplineAlgorithms::PAR_CHECK_TOL = 1e-5;
 
 bool BSplineAlgorithms::isUDirClosed(const TColgp_Array2OfPnt& points, double tolerance)
 {

--- a/src/internal/BSplineAlgorithms.h
+++ b/src/internal/BSplineAlgorithms.h
@@ -42,6 +42,9 @@ public:
     /// Tolerance for closed curve detection
     static const double REL_TOL_CLOSED;
 
+	/// Tolerance for comparing curve parameters
+    static const double PAR_CHECK_TOL;
+
     /**
      * @brief computeParamsBSplineCurve:
      *          Computes the parameters of a Geom_BSplineCurve at the given points

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -34,6 +34,12 @@ T Clamp(T val, T min, T max)
     return std::max(min, std::min(val, max));
 }
 
+/**
+ * @brief Checks that ends of 2 curves not sharing same point
+ *
+ * @param curve1 first curve
+ * @param curve2 second curve
+ */
 bool curvesAreSame(Handle(Geom_Curve) curve1, Handle(Geom_Curve) curve2)
 {
     gp_Pnt first = curve1->Value(curve1->FirstParameter());

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -87,6 +87,10 @@ void InterpolateCurveNetwork::ComputeIntersections(math_Matrix& intersection_par
                 // there is no way to let API user know it upfront. So we will handle it later
                 // Commented code below was working fine anly if curves passed to API were already sorte in correct order 
                 // and first curve in profiles was intersecting guide in a smallest parameter value
+
+                // Use first intersection here - should be pretty safe to do so
+                intersection_params_u(spline_u_idx, spline_v_idx) = currentIntersections[0].first;
+                intersection_params_v(spline_u_idx, spline_v_idx) = currentIntersections[0].second;
             }
             /*
 

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -82,12 +82,12 @@ void InterpolateCurveNetwork::ComputeIntersections(math_Matrix& intersection_par
                 intersection_params_u(spline_u_idx, spline_v_idx) = currentIntersections[0].first;
                 intersection_params_v(spline_u_idx, spline_v_idx) = currentIntersections[0].second;
             }
-
-			// NB: We couldn't handle closed curves here, because we did't know vhat profile/guide intesect in lowest parameter and 
-			// there is no way to let API user know it upfront. So we will handle it later
-			// Commented code below was working fine anly if curves passed to API were already sorte in correct order 
-			// and first curve in profiles was intersecting guide in a smallest parameter value
-
+            else if (currentIntersections.size() == 2) {
+                // NB: We couldn't handle closed curves here, because we did't know vhat profile/guide intesect in lowest parameter and 
+                // there is no way to let API user know it upfront. So we will handle it later
+                // Commented code below was working fine anly if curves passed to API were already sorte in correct order 
+                // and first curve in profiles was intersecting guide in a smallest parameter value
+            }
             /*
 
                 // for closed curves

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -43,9 +43,12 @@ T Clamp(T val, T min, T max)
 bool curvesAreSame(Handle(Geom_Curve) curve1, Handle(Geom_Curve) curve2)
 {
     gp_Pnt first = curve1->Value(curve1->FirstParameter());
+    gp_Pnt second = curve1->Value(curve1->LastParameter());
 
-    if (first.IsEqual(curve2->Value(curve2->FirstParameter()), Precision::Confusion()) ||
-        first.IsEqual(curve2->Value(curve2->LastParameter()), Precision::Confusion())) {
+    if ((first.IsEqual(curve2->Value(curve2->FirstParameter()), Precision::Confusion()) ||
+            first.IsEqual(curve2->Value(curve2->LastParameter()), Precision::Confusion())) &&
+        (second.IsEqual(curve2->Value(curve2->FirstParameter()), Precision::Confusion()) ||
+            second.IsEqual(curve2->Value(curve2->LastParameter()), Precision::Confusion()))) {
         return true;
     }
 

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -247,7 +247,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
                     tmp_intersection_params_v(spline_u_idx, spline_v_idx);
             }
             intersection_params_u(spline_u_idx, nGuides - 1) =
-				tmp_intersection_params_u(spline_u_idx, 0) < Precision::Intersection() // actually 1e-5
+				tmp_intersection_params_u(spline_u_idx, 0) < Precision::Approximation() // actually 1e-6
                 ? 1.0
                 : tmp_intersection_params_u(spline_u_idx, 0);
 
@@ -269,7 +269,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
             intersection_params_u(nProfiles - 1, spline_v_idx) =
                 tmp_intersection_params_u(0, spline_v_idx);
             intersection_params_v(nProfiles - 1, spline_v_idx) =
-                tmp_intersection_params_v(0, spline_v_idx) < Precision::Intersection() // actually 1e-5
+                tmp_intersection_params_v(0, spline_v_idx) < Precision::Approximation() // actually 1e-6
                 ? 1.0
                 : tmp_intersection_params_v(0, spline_v_idx);
         }
@@ -301,7 +301,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
         newParametersGuides.push_back(sum / nGuides);
     }
 
-    if (newParametersProfiles.front() > Precision::Intersection() || newParametersGuides.front() > Precision::Intersection()) {
+    if (newParametersProfiles.front() > Precision::Approximation() || newParametersGuides.front() > Precision::Approximation()) {
         throw error("At least one B-splines has no intersection at the beginning.");
     }
 
@@ -338,20 +338,20 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
         }
 
         // eliminate small inaccuracies at the first knot
-        if (std::abs(oldParametersProfile.front()) < Precision::Intersection()) {
+        if (std::abs(oldParametersProfile.front()) < Precision::Approximation()) {
             oldParametersProfile.front() = 0;
         }
 
-        if (std::abs(newParametersProfiles.front()) < Precision::Intersection()) {
+        if (std::abs(newParametersProfiles.front()) < Precision::Approximation()) {
             newParametersProfiles.front() = 0;
         }
 
         // eliminate small inaccuracies at the last knot
-        if (std::abs(oldParametersProfile.back() - 1) < Precision::Intersection()) {
+        if (std::abs(oldParametersProfile.back() - 1) < Precision::Approximation()) {
             oldParametersProfile.back() = 1;
         }
 
-        if (std::abs(newParametersProfiles.back() - 1) < Precision::Intersection()) {
+        if (std::abs(newParametersProfiles.back() - 1) < Precision::Approximation()) {
             newParametersProfiles.back() = 1;
         }
 
@@ -368,20 +368,20 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
         }
 
         // eliminate small inaccuracies at the first knot
-        if (std::abs(oldParameterGuide.front()) < Precision::Intersection()) {
+        if (std::abs(oldParameterGuide.front()) < Precision::Approximation()) {
             oldParameterGuide.front() = 0;
         }
 
-        if (std::abs(newParametersGuides.front()) < Precision::Intersection()) {
+        if (std::abs(newParametersGuides.front()) < Precision::Approximation()) {
             newParametersGuides.front() = 0;
         }
 
         // eliminate small inaccuracies at the last knot
-        if (std::abs(oldParameterGuide.back() - 1) < Precision::Intersection()) {
+        if (std::abs(oldParameterGuide.back() - 1) < Precision::Approximation()) {
             oldParameterGuide.back() = 1;
         }
 
-        if (std::abs(newParametersGuides.back() - 1) < Precision::Intersection()) {
+        if (std::abs(newParametersGuides.back() - 1) < Precision::Approximation()) {
             newParametersGuides.back() = 1;
         }
 

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -247,7 +247,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
                     tmp_intersection_params_v(spline_u_idx, spline_v_idx);
             }
             intersection_params_u(spline_u_idx, nGuides - 1) =
-				tmp_intersection_params_u(spline_u_idx, 0) < Precision::Approximation() // actually 1e-6
+				tmp_intersection_params_u(spline_u_idx, 0) < BSplineAlgorithms::PAR_CHECK_TOL // actually 1e-5
                 ? 1.0
                 : tmp_intersection_params_u(spline_u_idx, 0);
 
@@ -269,7 +269,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
             intersection_params_u(nProfiles - 1, spline_v_idx) =
                 tmp_intersection_params_u(0, spline_v_idx);
             intersection_params_v(nProfiles - 1, spline_v_idx) =
-                tmp_intersection_params_v(0, spline_v_idx) < Precision::Approximation() // actually 1e-6
+                tmp_intersection_params_v(0, spline_v_idx) < BSplineAlgorithms::PAR_CHECK_TOL // actually 1e-5
                 ? 1.0
                 : tmp_intersection_params_v(0, spline_v_idx);
         }
@@ -301,7 +301,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
         newParametersGuides.push_back(sum / nGuides);
     }
 
-    if (newParametersProfiles.front() > Precision::Approximation() || newParametersGuides.front() > Precision::Approximation()) {
+    if (newParametersProfiles.front() > BSplineAlgorithms::PAR_CHECK_TOL || newParametersGuides.front() > BSplineAlgorithms::PAR_CHECK_TOL) {
         throw error("At least one B-splines has no intersection at the beginning.");
     }
 
@@ -338,20 +338,20 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
         }
 
         // eliminate small inaccuracies at the first knot
-        if (std::abs(oldParametersProfile.front()) < Precision::Approximation()) {
+        if (std::abs(oldParametersProfile.front()) < BSplineAlgorithms::PAR_CHECK_TOL) {
             oldParametersProfile.front() = 0;
         }
 
-        if (std::abs(newParametersProfiles.front()) < Precision::Approximation()) {
+        if (std::abs(newParametersProfiles.front()) < BSplineAlgorithms::PAR_CHECK_TOL) {
             newParametersProfiles.front() = 0;
         }
 
         // eliminate small inaccuracies at the last knot
-        if (std::abs(oldParametersProfile.back() - 1) < Precision::Approximation()) {
+        if (std::abs(oldParametersProfile.back() - 1) < BSplineAlgorithms::PAR_CHECK_TOL) {
             oldParametersProfile.back() = 1;
         }
 
-        if (std::abs(newParametersProfiles.back() - 1) < Precision::Approximation()) {
+        if (std::abs(newParametersProfiles.back() - 1) < BSplineAlgorithms::PAR_CHECK_TOL) {
             newParametersProfiles.back() = 1;
         }
 
@@ -368,20 +368,20 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
         }
 
         // eliminate small inaccuracies at the first knot
-        if (std::abs(oldParameterGuide.front()) < Precision::Approximation()) {
+        if (std::abs(oldParameterGuide.front()) < BSplineAlgorithms::PAR_CHECK_TOL) {
             oldParameterGuide.front() = 0;
         }
 
-        if (std::abs(newParametersGuides.front()) < Precision::Approximation()) {
+        if (std::abs(newParametersGuides.front()) < BSplineAlgorithms::PAR_CHECK_TOL) {
             newParametersGuides.front() = 0;
         }
 
         // eliminate small inaccuracies at the last knot
-        if (std::abs(oldParameterGuide.back() - 1) < Precision::Approximation()) {
+        if (std::abs(oldParameterGuide.back() - 1) < BSplineAlgorithms::PAR_CHECK_TOL) {
             oldParameterGuide.back() = 1;
         }
 
-        if (std::abs(newParametersGuides.back() - 1) < Precision::Approximation()) {
+        if (std::abs(newParametersGuides.back() - 1) < BSplineAlgorithms::PAR_CHECK_TOL) {
             newParametersGuides.back() = 1;
         }
 

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -35,7 +35,7 @@ T Clamp(T val, T min, T max)
 }
 
 /**
- * @brief Checks that ends of 2 curves not sharing same point
+ * @brief Checks that ends of 2 curves are sharing same point
  *
  * @param curve1 first curve
  * @param curve2 second curve

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -78,28 +78,22 @@ InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_C
     // after sorting the intersection matrix
     std::vector<Handle(Geom_Curve)> uniqueProfiles;
     for (const auto& profile : profiles) {
-        bool isDuplicate = false;
-        for (const auto& uniqueProfile : uniqueProfiles) {
-            if (curvesAreSame(profile, uniqueProfile)) {
-                isDuplicate = true;
-                break;
-            }
-        }
-        if (!isDuplicate) {
+        const bool isUnique = std::none_of(uniqueProfiles.begin(), uniqueProfiles.end(), [&](const Handle(Geom_Curve) & curve) {
+            return curvesAreSame(profile, curve);
+        });
+
+        if (isUnique) {
             uniqueProfiles.push_back(profile);
         }
     }
 
     std::vector<Handle(Geom_Curve)> uniqueGuides;
     for (const auto& guide : guides) {
-        bool isDuplicate = false;
-        for (const auto& uniqueGuide : uniqueGuides) {
-            if (curvesAreSame(guide, uniqueGuide)) {
-                isDuplicate = true;
-                break;
-            }
-        }
-        if (!isDuplicate) {
+        const bool isUnique = std::none_of(uniqueGuides.begin(), uniqueGuides.end(), [&](const Handle(Geom_Curve) & curve) {
+            return curvesAreSame(guide, curve);
+        });
+
+        if (isUnique) {
             uniqueGuides.push_back(guide);
         }
     }
@@ -120,15 +114,11 @@ InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_C
     m_guides.reserve(uniqueGuides.size());
 
     // Copy the curves
-    for (std::vector<Handle(Geom_Curve)>::const_iterator it = uniqueProfiles.begin();
-        it != uniqueProfiles.end();
-        ++it) {
-        m_profiles.push_back(GeomConvert::CurveToBSplineCurve(*it));
+    for (auto&& profile : uniqueProfiles) {
+        m_profiles.push_back(GeomConvert::CurveToBSplineCurve(profile));
     }
-    for (std::vector<Handle(Geom_Curve)>::const_iterator it = uniqueGuides.begin();
-        it != uniqueGuides.end();
-        ++it) {
-        m_guides.push_back(GeomConvert::CurveToBSplineCurve(*it));
+    for (auto&& guide : uniqueGuides) {
+        m_guides.push_back(GeomConvert::CurveToBSplineCurve(guide));
     }
 }
 
@@ -214,7 +204,7 @@ void InterpolateCurveNetwork::MakeCurvesCompatible()
     math_Matrix tmp_intersection_params_v(0, nProfiles - 1, 0, nGuides - 1);
 
     // closed profiles/guides should not be handled by this method ideally
-	// it will only work if first profile/guide intersects with guide/profile at it's lowest parameter
+    // it will only work if first profile/guide intersects with guide/profile at it's lowest parameter
     // We cover case when curves alredy somewhat sorted and for closed profiles we already have 1 additional guide
     ComputeIntersections(tmp_intersection_params_u, tmp_intersection_params_v);
 


### PR DESCRIPTION
Code should decide by itself what result surface to create. Leave it to the api user leads to unstable/unpredictable results and, without harsh modifications of code, not practical.

The main problem was that when profiles are closed api was expecting additional guide from user - copy of the first guide at the end of collection. It works, but only when 1st guide in a collection intersect profile at lowest parameter, so basically collection already sorted. All other cases were leading to failure, since before sorting we do not know what guide will be the first one and as result cannot decide witch guide to duplicate. 

It's just a draft that allowed me to play a bit more with a lib and finally build surface over one of the test data example (nacelle). Hope it will help improve the library that has pretty good potential. 

If you have any suggestions - I'll be happy to discuss. Meanwhile I'll continue my journey over the code trying to make it fork for my application.

![image](https://github.com/user-attachments/assets/122b0da0-bf30-418d-b145-7a39f53f63d1)
