### PR TITLE
interpolate_curve_network function that can take curves already converted to B-Spline added to ease integration with CADs

### DIFF
--- a/src/internal/BSplineAlgorithms.cpp
+++ b/src/internal/BSplineAlgorithms.cpp
@@ -475,7 +475,7 @@ std::vector<double> BSplineAlgorithms::knotsFromCurveParameters(std::vector<doub
     return knots;
 }
 
-std::vector<Handle (Geom_BSplineCurve)> BSplineAlgorithms::toBSplines(const std::vector<Handle (Geom_Curve)> curves)
+std::vector<Handle(Geom_BSplineCurve)> BSplineAlgorithms::toBSplines(const std::vector<Handle(Geom_Curve)>& curves)
 {
     std::vector<Handle(Geom_BSplineCurve)> result;
 

--- a/src/internal/BSplineAlgorithms.cpp
+++ b/src/internal/BSplineAlgorithms.cpp
@@ -475,6 +475,17 @@ std::vector<double> BSplineAlgorithms::knotsFromCurveParameters(std::vector<doub
     return knots;
 }
 
+std::vector<Handle (Geom_BSplineCurve)> BSplineAlgorithms::toBSplines(const std::vector<Handle (Geom_Curve)> curves)
+{
+    std::vector<Handle(Geom_BSplineCurve)> result;
+
+    std::transform(curves.begin(), curves.end(), std::back_inserter(result), [](const auto& curve) {
+        return  GeomConvert::CurveToBSplineCurve(curve);
+    });
+
+    return result;
+}
+
 double BSplineAlgorithms::scale(const TColgp_Array2OfPnt& points)
 {
     double theScale = 0.;

--- a/src/internal/BSplineAlgorithms.h
+++ b/src/internal/BSplineAlgorithms.h
@@ -253,6 +253,9 @@ public:
 
     /// Trims a bspline curve
     static Handle(Geom_BSplineCurve) trimCurve(const Handle(Geom_BSplineCurve)& curve, double umin, double umax);
+
+    // Converts a curve array into a b-spline array
+    static std::vector<Handle(Geom_BSplineCurve)> toBSplines(const std::vector<Handle(Geom_Curve)> curves);
 };
 } // namespace occ_gordon_internal
 

--- a/src/internal/BSplineAlgorithms.h
+++ b/src/internal/BSplineAlgorithms.h
@@ -255,7 +255,7 @@ public:
     static Handle(Geom_BSplineCurve) trimCurve(const Handle(Geom_BSplineCurve)& curve, double umin, double umax);
 
     // Converts a curve array into a b-spline array
-    static std::vector<Handle(Geom_BSplineCurve)> toBSplines(const std::vector<Handle(Geom_Curve)> curves);
+    static std::vector<Handle(Geom_BSplineCurve)> toBSplines(const std::vector<Handle(Geom_Curve)>& curves);
 };
 } // namespace occ_gordon_internal
 

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -34,6 +34,31 @@ T Clamp(T val, T min, T max)
     return std::max(min, std::min(val, max));
 }
 
+InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_Curve)>& profiles,
+                                                            const std::vector<Handle(Geom_Curve)>& guides,
+                                                            double spatialTol)
+    : m_hasPerformed(false)
+    , m_spatialTol(spatialTol)
+{
+    std::vector<Handle(Geom_BSplineCurve)> ucurves_bsplines, vcurves_bsplines;
+
+    ucurves_bsplines.reserve(profiles.size());
+    vcurves_bsplines.reserve(guides.size());
+
+    try {
+        for (const auto& profile : profiles) {
+            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(profile));
+        }
+        for (const auto& guide : guides) {
+            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(guide));
+        }
+    }
+    catch (Standard_Failure& err) {
+        throw std::runtime_error(std::string("Error converting curves to B-splines: ")
+            + err.GetMessageString());
+    }
+}
+
 InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_BSplineCurve)>& profiles,
                                                             const std::vector<Handle(Geom_BSplineCurve)>& guides,
                                                             double spatialTol)
@@ -477,6 +502,11 @@ void InterpolateCurveNetwork::Perform()
 }
 
 Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle (Geom_BSplineCurve)> &profiles, const std::vector<Handle (Geom_BSplineCurve)> &guides, double tol)
+{
+    return InterpolateCurveNetwork(profiles, guides, tol).Surface();
+}
+
+Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_Curve)>& profiles, const std::vector<Handle(Geom_Curve)>& guides, double tol)
 {
     return InterpolateCurveNetwork(profiles, guides, tol).Surface();
 }

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -37,26 +37,9 @@ T Clamp(T val, T min, T max)
 InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_Curve)>& profiles,
                                                             const std::vector<Handle(Geom_Curve)>& guides,
                                                             double spatialTol)
-    : m_hasPerformed(false)
-    , m_spatialTol(spatialTol)
+    : InterpolateCurveNetwork(BSplineAlgorithms::toBSplines(profiles),
+                              BSplineAlgorithms::toBSplines(guides), spatialTol)
 {
-    std::vector<Handle(Geom_BSplineCurve)> ucurves_bsplines, vcurves_bsplines;
-
-    ucurves_bsplines.reserve(profiles.size());
-    vcurves_bsplines.reserve(guides.size());
-
-    try {
-        for (const auto& profile : profiles) {
-            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(profile));
-        }
-        for (const auto& guide : guides) {
-            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(guide));
-        }
-    }
-    catch (Standard_Failure& err) {
-        throw std::runtime_error(std::string("Error converting curves to B-splines: ")
-            + err.GetMessageString());
-    }
 }
 
 InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_BSplineCurve)>& profiles,

--- a/src/internal/InterpolateCurveNetwork.cpp
+++ b/src/internal/InterpolateCurveNetwork.cpp
@@ -34,29 +34,8 @@ T Clamp(T val, T min, T max)
     return std::max(min, std::min(val, max));
 }
 
-/**
- * @brief Checks that ends of 2 curves are sharing same point
- *
- * @param curve1 first curve
- * @param curve2 second curve
- */
-bool curvesAreSame(Handle(Geom_Curve) curve1, Handle(Geom_Curve) curve2)
-{
-    gp_Pnt first = curve1->Value(curve1->FirstParameter());
-    gp_Pnt second = curve1->Value(curve1->LastParameter());
-
-    if ((first.IsEqual(curve2->Value(curve2->FirstParameter()), Precision::Confusion()) ||
-            first.IsEqual(curve2->Value(curve2->LastParameter()), Precision::Confusion())) &&
-        (second.IsEqual(curve2->Value(curve2->FirstParameter()), Precision::Confusion()) ||
-            second.IsEqual(curve2->Value(curve2->LastParameter()), Precision::Confusion()))) {
-        return true;
-    }
-
-    return false;
-}
-
-InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_Curve)>& profiles,
-                                                            const std::vector<Handle(Geom_Curve)>& guides,
+InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_BSplineCurve)>& profiles,
+                                                            const std::vector<Handle(Geom_BSplineCurve)>& guides,
                                                             double spatialTol)
     : m_hasPerformed(false)
     , m_spatialTol(spatialTol)
@@ -76,10 +55,10 @@ InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_C
     // it should be enough, since surface closed in both U and V not supported by algorithm
     // if profiles or guides are closed curves, we will add the first curve at the end later
     // after sorting the intersection matrix
-    std::vector<Handle(Geom_Curve)> uniqueProfiles;
+    std::vector<Handle(Geom_BSplineCurve)> uniqueProfiles;
     for (const auto& profile : profiles) {
-        const bool isUnique = std::none_of(uniqueProfiles.begin(), uniqueProfiles.end(), [&](const Handle(Geom_Curve) & curve) {
-            return curvesAreSame(profile, curve);
+        const bool isUnique = std::none_of(uniqueProfiles.begin(), uniqueProfiles.end(), [&](const Handle(Geom_BSplineCurve) & curve) {
+            return profile->IsEqual(curve, Precision::Confusion());
         });
 
         if (isUnique) {
@@ -87,10 +66,10 @@ InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_C
         }
     }
 
-    std::vector<Handle(Geom_Curve)> uniqueGuides;
+    std::vector<Handle(Geom_BSplineCurve)> uniqueGuides;
     for (const auto& guide : guides) {
-        const bool isUnique = std::none_of(uniqueGuides.begin(), uniqueGuides.end(), [&](const Handle(Geom_Curve) & curve) {
-            return curvesAreSame(guide, curve);
+        const bool isUnique = std::none_of(uniqueGuides.begin(), uniqueGuides.end(), [&](const Handle(Geom_BSplineCurve) & curve) {
+            return guide->IsEqual(curve, Precision::Confusion());
         });
 
         if (isUnique) {
@@ -113,12 +92,12 @@ InterpolateCurveNetwork::InterpolateCurveNetwork(const std::vector<Handle(Geom_C
     m_profiles.reserve(uniqueProfiles.size());
     m_guides.reserve(uniqueGuides.size());
 
-    // Copy the curves
+    // Store the curves
     for (auto&& profile : uniqueProfiles) {
-        m_profiles.push_back(GeomConvert::CurveToBSplineCurve(profile));
+        m_profiles.push_back(profile);
     }
     for (auto&& guide : uniqueGuides) {
-        m_guides.push_back(GeomConvert::CurveToBSplineCurve(guide));
+        m_guides.push_back(guide);
     }
 }
 
@@ -497,7 +476,7 @@ void InterpolateCurveNetwork::Perform()
     m_hasPerformed = true;
 }
 
-Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle (Geom_Curve)> &profiles, const std::vector<Handle (Geom_Curve)> &guides, double tol)
+Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle (Geom_BSplineCurve)> &profiles, const std::vector<Handle (Geom_BSplineCurve)> &guides, double tol)
 {
     return InterpolateCurveNetwork(profiles, guides, tol).Surface();
 }

--- a/src/internal/InterpolateCurveNetwork.h
+++ b/src/internal/InterpolateCurveNetwork.h
@@ -39,8 +39,8 @@ public:
      * @param guides   The guides curves to be interpolated
      * @param spatialTolerance Maximum allowed distance between each guide and profile (in theory they must intersect)
      */
-    InterpolateCurveNetwork(const std::vector<Handle(Geom_Curve)>& profiles,
-                                             const std::vector<Handle(Geom_Curve)>& guides,
+    InterpolateCurveNetwork(const std::vector<Handle(Geom_BSplineCurve)>& profiles,
+                                             const std::vector<Handle(Geom_BSplineCurve)>& guides,
                                              double spatialTolerance);
 
     operator Handle(Geom_BSplineSurface) ();
@@ -91,8 +91,8 @@ private:
 };
 
 /// Convenience function calling InterpolateCurveNetwork
-Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_Curve)>& profiles,
-                                                              const std::vector<Handle(Geom_Curve)>& guides,
+Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_BSplineCurve)>& profiles,
+                                                              const std::vector<Handle(Geom_BSplineCurve)>& guides,
                                                               double spatialTol = 3e-4);
 
 } // namespace occ_gordon_internal

--- a/src/internal/InterpolateCurveNetwork.h
+++ b/src/internal/InterpolateCurveNetwork.h
@@ -105,6 +105,11 @@ Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_
                                                               const std::vector<Handle(Geom_BSplineCurve)>& guides,
                                                               double spatialTol = 3e-4);
 
+/// Convenience function calling InterpolateCurveNetwork
+Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_Curve)>& profiles,
+                                                  const std::vector<Handle(Geom_Curve)>& guides,
+                                                  double spatialTol = 3e-4);
+
 } // namespace occ_gordon_internal
 
 #endif // INTERPOLATECURVENETWORK_H

--- a/src/internal/InterpolateCurveNetwork.h
+++ b/src/internal/InterpolateCurveNetwork.h
@@ -43,6 +43,16 @@ public:
                                              const std::vector<Handle(Geom_BSplineCurve)>& guides,
                                              double spatialTolerance);
 
+    /**
+     * @brief InterpolateCurveNetwork interpolated a curve network of guide curves and profiles curves
+     * @param profiles The profiles to be interpolated
+     * @param guides   The guides curves to be interpolated
+     * @param spatialTolerance Maximum allowed distance between each guide and profile (in theory they must intersect)
+     */
+    InterpolateCurveNetwork(const std::vector<Handle(Geom_Curve)>& profiles,
+                                             const std::vector<Handle(Geom_Curve)>& guides,
+                                             double spatialTolerance);
+
     operator Handle(Geom_BSplineSurface) ();
     
     /// Returns the interpolation surface

--- a/src/occ_gordon/occ_gordon.cpp
+++ b/src/occ_gordon/occ_gordon.cpp
@@ -11,6 +11,8 @@
 
 #include "occ_gordon.h"
 
+#include <GeomConvert.hxx>
+
 #include "internal/InterpolateCurveNetwork.h"
 #include "internal/Error.h"
 
@@ -19,6 +21,30 @@ namespace occ_gordon
 
 Handle(Geom_BSplineSurface) interpolate_curve_network(const std::vector<Handle (Geom_Curve)> &ucurves,
                                                       const std::vector<Handle (Geom_Curve)> &vcurves,
+                                                      double tolerance)
+{
+    std::vector<Handle(Geom_BSplineCurve)> ucurves_bsplines, vcurves_bsplines;
+
+    ucurves_bsplines.reserve(ucurves.size());
+    vcurves_bsplines.reserve(vcurves.size());
+
+    try {
+		for (const auto& profile : ucurves) {
+			ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(profile));
+		}
+		for (const auto& guide : vcurves) {
+            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(guide));
+        }
+    }
+    catch(Standard_Failure& err) {
+        throw std::runtime_error(std::string("Error converting curves to B-splines: ")
+            + err.GetMessageString());
+    }
+    return interpolate_curve_network(ucurves_bsplines, vcurves_bsplines, tolerance);
+}
+
+Handle(Geom_BSplineSurface) interpolate_curve_network(const std::vector<Handle (Geom_BSplineCurve)> &ucurves,
+                                                      const std::vector<Handle (Geom_BSplineCurve)> &vcurves,
                                                       double tolerance)
 {
     try {

--- a/src/occ_gordon/occ_gordon.cpp
+++ b/src/occ_gordon/occ_gordon.cpp
@@ -29,10 +29,10 @@ Handle(Geom_BSplineSurface) interpolate_curve_network(const std::vector<Handle (
     vcurves_bsplines.reserve(vcurves.size());
 
     try {
-		for (const auto& profile : ucurves) {
-			ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(profile));
-		}
-		for (const auto& guide : vcurves) {
+        for (const auto& profile : ucurves) {
+            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(profile));
+        }
+        for (const auto& guide : vcurves) {
             ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(guide));
         }
     }

--- a/src/occ_gordon/occ_gordon.cpp
+++ b/src/occ_gordon/occ_gordon.cpp
@@ -16,31 +16,22 @@
 #include "internal/InterpolateCurveNetwork.h"
 #include "internal/Error.h"
 
+#include "internal/BSplineAlgorithms.h"
+
 namespace occ_gordon
 {
 
-Handle(Geom_BSplineSurface) interpolate_curve_network(const std::vector<Handle (Geom_Curve)> &ucurves,
-                                                      const std::vector<Handle (Geom_Curve)> &vcurves,
+Handle(Geom_BSplineSurface) interpolate_curve_network(const std::vector<Handle (Geom_Curve)>& ucurves,
+                                                      const std::vector<Handle (Geom_Curve)>& vcurves,
                                                       double tolerance)
 {
-    std::vector<Handle(Geom_BSplineCurve)> ucurves_bsplines, vcurves_bsplines;
-
-    ucurves_bsplines.reserve(ucurves.size());
-    vcurves_bsplines.reserve(vcurves.size());
-
     try {
-        for (const auto& profile : ucurves) {
-            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(profile));
-        }
-        for (const auto& guide : vcurves) {
-            ucurves_bsplines.push_back(GeomConvert::CurveToBSplineCurve(guide));
-        }
+        return interpolate_curve_network(occ_gordon_internal::BSplineAlgorithms::toBSplines(ucurves),
+                                         occ_gordon_internal::BSplineAlgorithms::toBSplines(vcurves), tolerance);
     }
-    catch(Standard_Failure& err) {
-        throw std::runtime_error(std::string("Error converting curves to B-splines: ")
-            + err.GetMessageString());
+    catch(occ_gordon_internal::error& err) {
+        throw std::runtime_error(std::string("Error creating gordon surface: ") + err.what());
     }
-    return interpolate_curve_network(ucurves_bsplines, vcurves_bsplines, tolerance);
 }
 
 Handle(Geom_BSplineSurface) interpolate_curve_network(const std::vector<Handle (Geom_BSplineCurve)> &ucurves,

--- a/src/occ_gordon/occ_gordon.h
+++ b/src/occ_gordon/occ_gordon.h
@@ -9,6 +9,7 @@
 
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_Curve.hxx>
+#include <Geom_BSplineCurve.hxx>
 
 #include <vector>
 
@@ -34,6 +35,27 @@ namespace occ_gordon
 OCC_GORDON_EXPORT Handle(Geom_BSplineSurface)
     interpolate_curve_network(const std::vector<Handle(Geom_Curve)>& ucurves,
                               const std::vector<Handle(Geom_Curve)>& vcurves,
+                              double tolerance);
+
+/**
+ * @brief Interpolates the curve network by a B-spline surface
+ *
+ * This uses the Gordon interpolation method.
+ * The u curves and v curves must intersect each other within the tolerance.
+ *
+ * __Note:__ The input curves are reparametrized to fullfill the compatibity criteria of the gordon method,
+ *       which might introduce a small error.
+ *
+ * @throws std::runtime_error in case the surface cannot be built
+ *
+ * @param ucurves Multiple B-Spline curves that will be interpolated in u direction by the final shape
+ * @param vcurves Multiple B-Spline curves that will be interpolated in v direction by the final shape,
+ *                must intersect the ucurves
+ * @param tolerance Tolerance, in which the u- and v-curves need to intersect each other
+ */
+OCC_GORDON_EXPORT Handle(Geom_BSplineSurface)
+    interpolate_curve_network(const std::vector<Handle(Geom_BSplineCurve)>& ucurves,
+                              const std::vector<Handle(Geom_BSplineCurve)>& vcurves,
                               double tolerance);
 
 } // namespace geoml


### PR DESCRIPTION
As we talked before I added overload of endpoint that can be feed with Geom_BSplineCurve instead of Geom_Curve. Still not able to build a tests, unfortunately, but at least it's working in a FreeCad on my test env. hope tests will not fail. 