### PR TITLE
fix: gradient calculation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Fixed
+ - Fixed gradient computation in B-spline intersection. This should improve
+   robustness and convergence of the intersection computation.
+   Thanks: @gongfan99 🙏
+   @joergbrech, @AntonReiswich: Tagging you here. You might need to include this into TiGL / geoml.

--- a/src/internal/IntersectBSplines.cpp
+++ b/src/internal/IntersectBSplines.cpp
@@ -312,7 +312,7 @@ namespace
             gp_Vec diff = p1.XYZ() - p2.XYZ();
             F = diff.SquareMagnitude();
             G(1) = 2. * diff.Dot(d1) * d_getUParam(X.Value(1));
-            G(2) = -2. * diff.Dot(d2) * d_getUParam(X.Value(2));
+            G(2) = -2. * diff.Dot(d2)  * d_getVParam(X.Value(2));
 
             return true;
         }
@@ -320,7 +320,50 @@ namespace
     private:
         const Handle(Geom_Curve) m_c1, m_c2;
     };
-   
+
+
+    void CheckGradient(math_MultipleVarFunctionWithGradient& func, const math_Vector& X, double step)
+    {
+        int nvars = func.NbVariables();
+
+        // Analytical gradient and temporary storage
+        math_Vector analyticalGrad(1, nvars);
+        math_Vector dummy(1, nvars);
+        double baseValue = 0.0;
+
+        // Evaluate function and analytical gradient at X
+        func.Values(X, baseValue, analyticalGrad);
+
+        // Compute numerical gradient using finite differences
+        math_Vector numericalGrad(1, nvars);
+        for (int i = 1; i <= 2; ++i) {
+            math_Vector Xplus(X);
+            math_Vector Xminus(X);
+
+            Xplus.Value(i) += step;
+            Xminus.Value(i) -= step;
+
+            double f_plus = 0.0, f_minus = 0.0;
+            func.Values(Xplus, f_plus, dummy);
+            func.Values(Xminus, f_minus, dummy);
+
+            // Central difference for better accuracy
+            numericalGrad.Value(i) = (f_plus - f_minus) / (2.0 * step);
+        }
+
+        // Compare analytical vs. numerical gradients
+        std::cout << std::fixed << std::setprecision(8);
+        std::cout << "=== Gradient Check ===" << std::endl;
+
+        for (int i = 1; i <= nvars; ++i) {
+            double diff = std::abs(numericalGrad.Value(i) - analyticalGrad.Value(i));
+            std::cout << "dF/dX" << i << " | Analytical: " << analyticalGrad.Value(i)
+                      << "  Numerical: " << numericalGrad.Value(i)
+                      << "  | Diff: " << diff << std::endl;
+        }
+
+        std::cout << "======================\n" << std::endl;
+    }
 
 } // namespace
 
@@ -389,6 +432,8 @@ std::vector<CurveIntersectionResult> IntersectBSplines(const Handle(Geom_BSpline
         guess(1) = 0.;
         guess(2) = 0.;
 
+        // Only comment in for debugging purposes
+        //CheckGradient(obj, guess, 1e-6);
 
         math_FRPR optimizer(obj, 1e-10, 200);
         optimizer.Perform(obj, guess);

--- a/src/internal/IntersectBSplines.cpp
+++ b/src/internal/IntersectBSplines.cpp
@@ -311,8 +311,8 @@ namespace
 
             gp_Vec diff = p1.XYZ() - p2.XYZ();
             F = diff.SquareMagnitude();
-            G(1) = 2. * diff.Dot(d1)* (m_c1->LastParameter()-m_c1->FirstParameter()) * d_getUParam(X.Value(1));
-            G(2) = -2. * diff.Dot(d2) * (m_c2->LastParameter()-m_c2->FirstParameter()) * d_getUParam(X.Value(2));
+            G(1) = 2. * diff.Dot(d1) * d_getUParam(X.Value(1));
+            G(2) = -2. * diff.Dot(d2) * d_getUParam(X.Value(2));
 
             return true;
         }


### PR DESCRIPTION
	modified:   src/internal/IntersectBSplines.cpp

Hey Dr. Siggel,

First of all, thanks for your generosity for sharing the gordon surface algorithm. I have converted it to a python version ocp_gordon which works very well. Occasionally there is a failure in the intersect point detection. After some debugging, it appears that the gradient calculation in the IntersectBSplines function has a typo. After the correction, the intersect point detection works much more stable now. Hence, I want to contribute back to your code.

I apologize that I do not have the C++ setup so cannot run the tests. But I have checked several times analytically to the gradient calculation.

Thanks again,
Fan Gong